### PR TITLE
Adds authentication methods for Google Reader Compatible syncing

### DIFF
--- a/Credentials.swift
+++ b/Credentials.swift
@@ -15,7 +15,8 @@ public enum CredentialsError: Error {
 
 public enum Credentials {
     case basic(username: String, password: String)
-    case googleLogin(username: String, password: String, apiUrl: URL, apiKey: String?)
+    case googleBasicLogin(username: String, password: String, url: URL)
+    case googleAuthLogin(username: String, apiKey: String, url: URL)
 //	case oauth2(token: String)
 }
 

--- a/Credentials.swift
+++ b/Credentials.swift
@@ -14,7 +14,8 @@ public enum CredentialsError: Error {
 }
 
 public enum Credentials {
-	case basic(username: String, password: String)
+    case basic(username: String, password: String)
+    case googleLogin(username: String, password: String, apiUrl: URL, apiKey: String?)
 //	case oauth2(token: String)
 }
 

--- a/Credentials.swift
+++ b/Credentials.swift
@@ -15,8 +15,8 @@ public enum CredentialsError: Error {
 
 public enum Credentials {
     case basic(username: String, password: String)
-    case googleBasicLogin(username: String, password: String, url: URL)
-    case googleAuthLogin(username: String, apiKey: String, url: URL)
+    case googleBasicLogin(username: String, password: String)
+    case googleAuthLogin(username: String, apiKey: String)
 //	case oauth2(token: String)
 }
 

--- a/CredentialsManager.swift
+++ b/CredentialsManager.swift
@@ -15,6 +15,11 @@ public struct CredentialsManager {
 		switch credentials {
 		case .basic(let username, let password):
 			try storeBasicCredentials(server: server, username: username, password: password)
+        case .googleLogin(let username, _, _, let apiKey):
+            guard let apiKey = apiKey else {
+                throw CredentialsError.incompleteCredentials
+            }
+            try storeBasicCredentials(server: server, username: username, password: apiKey)
 		}
 		
 	}

--- a/CredentialsManager.swift
+++ b/CredentialsManager.swift
@@ -68,8 +68,52 @@ public struct CredentialsManager {
 		}
 		
 	}
-	
-	
+    
+    public static func retrieveGoogleAuthCredentials(server: String, username: String) throws -> Credentials? {
+        
+        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrAccount as String: username,
+                                    kSecAttrServer as String: server,
+                                    kSecMatchLimit as String: kSecMatchLimitOne,
+                                    kSecReturnAttributes as String: true,
+                                    kSecReturnData as String: true]
+        
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        
+        guard status != errSecItemNotFound else {
+            return nil
+        }
+        
+        guard status == errSecSuccess else {
+            throw CredentialsError.unhandledError(status: status)
+        }
+        
+        guard let existingItem = item as? [String : Any],
+            let passwordData = existingItem[kSecValueData as String] as? Data,
+            let password = String(data: passwordData, encoding: String.Encoding.utf8) else {
+                return nil
+        }
+        
+        return Credentials.googleAuthLogin(username: username, apiKey: password)
+        
+    }
+    
+    public static func removeGoogleAuthCredentials(server: String, username: String) throws {
+        
+        let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
+                                    kSecAttrAccount as String: username,
+                                    kSecAttrServer as String: server,
+                                    kSecMatchLimit as String: kSecMatchLimitOne,
+                                    kSecReturnAttributes as String: true,
+                                    kSecReturnData as String: true]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw CredentialsError.unhandledError(status: status)
+        }
+        
+    }
 }
 
 // MARK: Private

--- a/CredentialsManager.swift
+++ b/CredentialsManager.swift
@@ -15,9 +15,9 @@ public struct CredentialsManager {
 		switch credentials {
 		case .basic(let username, let password):
 			try storeBasicCredentials(server: server, username: username, password: password)
-        case .googleBasicLogin(let username, let password, _):
+        case .googleBasicLogin(let username, let password):
             try storeBasicCredentials(server: server, username: username, password: password)
-        case .googleAuthLogin(let username, let apiKey, _):
+        case .googleAuthLogin(let username, let apiKey):
             try storeBasicCredentials(server: server, username: username, password: apiKey)
 		}
 		

--- a/CredentialsManager.swift
+++ b/CredentialsManager.swift
@@ -15,10 +15,9 @@ public struct CredentialsManager {
 		switch credentials {
 		case .basic(let username, let password):
 			try storeBasicCredentials(server: server, username: username, password: password)
-        case .googleLogin(let username, _, _, let apiKey):
-            guard let apiKey = apiKey else {
-                throw CredentialsError.incompleteCredentials
-            }
+        case .googleBasicLogin(let username, let password, _):
+            try storeBasicCredentials(server: server, username: username, password: password)
+        case .googleAuthLogin(let username, let apiKey, _):
             try storeBasicCredentials(server: server, username: username, password: apiKey)
 		}
 		

--- a/RSWeb/WebServices/Transport.swift
+++ b/RSWeb/WebServices/Transport.swift
@@ -11,6 +11,7 @@ import Foundation
 
 public enum TransportError: LocalizedError {
 	case noData
+    case noURL
 	case httpError(status: Int)
 	
 	public var errorDescription: String? {

--- a/RSWeb/WebServices/TransportJSON.swift
+++ b/RSWeb/WebServices/TransportJSON.swift
@@ -107,5 +107,34 @@ extension Transport {
 		}
 		
 	}
+    
+    /**
+     Sends the specified HTTP method with a Raw payload and returns JSON object(s).
+     */
+    public func send<R: Decodable>(request: URLRequest, method: String, data: Data, resultType: R.Type, dateDecoding: JSONDecoder.DateDecodingStrategy = .iso8601, completion: @escaping (Result<(HTTPURLResponse, R?), Error>) -> Void) {
+                
+        send(request: request, method: method, payload: data) { result in
+            
+            switch result {
+            case .success(let (response, data)):
+                do {
+                    if let data = data, !data.isEmpty {
+                        let decoder = JSONDecoder()
+                        decoder.dateDecodingStrategy = dateDecoding
+                        let decoded = try decoder.decode(R.self, from: data)
+                        completion(.success((response, decoded)))
+                    } else {
+                        completion(.success((response, nil)))
+                    }
+                } catch {
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+            
+        }
+        
+    }
 	
 }

--- a/URLRequest+RSWeb.swift
+++ b/URLRequest+RSWeb.swift
@@ -24,11 +24,12 @@ public extension URLRequest {
 			let base64 = data?.base64EncodedString()
 			let auth = "Basic \(base64 ?? "")"
 			setValue(auth, forHTTPHeaderField: HTTPRequestHeader.authorization)
-        case .googleLogin(_, _, _, let apiKey):
-            guard let apiKey = apiKey else {
-                // If we don't have an api_key yet, just return
-                return
-            }
+        case .googleBasicLogin(let username, let password, _):
+            setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            httpMethod = "POST"
+            let postData = "Email=\(username)&Passwd=\(password)"
+            httpBody = postData.data(using: String.Encoding.utf8)
+        case .googleAuthLogin(_, let apiKey, _):
             let auth = "GoogleLogin auth=\(apiKey)"
             setValue(auth, forHTTPHeaderField: HTTPRequestHeader.authorization)
 		}

--- a/URLRequest+RSWeb.swift
+++ b/URLRequest+RSWeb.swift
@@ -24,6 +24,13 @@ public extension URLRequest {
 			let base64 = data?.base64EncodedString()
 			let auth = "Basic \(base64 ?? "")"
 			setValue(auth, forHTTPHeaderField: HTTPRequestHeader.authorization)
+        case .googleLogin(_, _, _, let apiKey):
+            guard let apiKey = apiKey else {
+                // If we don't have an api_key yet, just return
+                return
+            }
+            let auth = "GoogleLogin auth=\(apiKey)"
+            setValue(auth, forHTTPHeaderField: HTTPRequestHeader.authorization)
 		}
 		
 		guard let conditionalGet = conditionalGet else {

--- a/URLRequest+RSWeb.swift
+++ b/URLRequest+RSWeb.swift
@@ -24,12 +24,12 @@ public extension URLRequest {
 			let base64 = data?.base64EncodedString()
 			let auth = "Basic \(base64 ?? "")"
 			setValue(auth, forHTTPHeaderField: HTTPRequestHeader.authorization)
-        case .googleBasicLogin(let username, let password, _):
+        case .googleBasicLogin(let username, let password):
             setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             httpMethod = "POST"
             let postData = "Email=\(username)&Passwd=\(password)"
             httpBody = postData.data(using: String.Encoding.utf8)
-        case .googleAuthLogin(_, let apiKey, _):
+        case .googleAuthLogin(_, let apiKey):
             let auth = "GoogleLogin auth=\(apiKey)"
             setValue(auth, forHTTPHeaderField: HTTPRequestHeader.authorization)
 		}


### PR DESCRIPTION
Issue: https://github.com/brentsimmons/NetNewsWire/issues/716 (part 1 of solution)

This Adds support for the two authentication token types that are used when talking to a Google Reader Compatible API. One is a long term username/password that is used as POST variables when authenticating with the API. This can be stored in the keychain. The other is an ephemeral (at least in theory) that is used as part of some operations but is not persisted in the keychain.

In addition, this adds another version of `send` to `TransportJSON` to allow sending JSON but retrieve raw data.