### PR TITLE
RSWeb refactor

### DIFF
--- a/Dictionary+RSWeb.swift
+++ b/Dictionary+RSWeb.swift
@@ -10,10 +10,7 @@ import Foundation
 
 public extension Dictionary where Key == String, Value == String  {
 
-	/// Turn a dictionary into string like `foo=bar&param2=some%20thing`.
-	///
-	/// - Returns: An URL-encoded query string, or `nil` if the dictionary is empty.
-
+	/// Translates a dictionary into a string like `foo=bar&param2=some%20thing`.
 	var urlQueryString: String? {
 
 		var components = URLComponents()

--- a/Dictionary+RSWeb.swift
+++ b/Dictionary+RSWeb.swift
@@ -8,39 +8,22 @@
 
 import Foundation
 
-public extension Dictionary  {
+public extension Dictionary where Key == String, Value == String  {
 
-	func urlQueryString() -> String? {
+	/// Turn a dictionary into string like `foo=bar&param2=some%20thing`.
+	///
+	/// - Returns: An URL-encoded query string, or `nil` if the dictionary is empty.
 
-		// Turn a dictionary into string like foo=bar&param2=some%20thing
-		// Return nil if empty dictionary.
+	var urlQueryString: String? {
 
-		if isEmpty {
-			return nil
+		var components = URLComponents()
+
+		components.queryItems = self.reduce(into: [URLQueryItem]()) {
+			$0.append(URLQueryItem(name: $1.key, value: $1.value))
 		}
 
-		var s = ""
-		var numberAdded = 0
-		for (key, value) in self {
+		let s = components.percentEncodedQuery
 
-			guard let key = key as? String, let value = value as? String else {
-				continue
-			}
-			guard let encodedKey = key.encodedForURLQuery(), let encodedValue = value.encodedForURLQuery() else {
-				continue
-			}
-
-			if numberAdded > 0 {
-				s += "&"
-			}
-			s += "\(encodedKey)=\(encodedValue)"
-			numberAdded += 1
-		}
-
-		if numberAdded < 1 {
-			return nil
-		}
-		
-		return s
+		return s == nil || s!.isEmpty ? nil : s
 	}
 }

--- a/HTTPConditionalGetInfo.swift
+++ b/HTTPConditionalGetInfo.swift
@@ -33,7 +33,7 @@ public struct HTTPConditionalGetInfo: Codable, Equatable {
 		self.init(lastModified: lastModified, etag: etag)
 	}
 	
-	public func addRequestHeadersToURLRequest(_ urlRequest: NSMutableURLRequest) {
+	public func addRequestHeadersToURLRequest(_ urlRequest: inout URLRequest) {
 		// Bug seen in the wild: lastModified with last possible 32-bit date, which is in 2038. Ignore those.
 		// TODO: drop this check in late 2037.
 		if let lastModified = lastModified, !lastModified.contains("2038") {

--- a/RSWeb.xcodeproj/project.pbxproj
+++ b/RSWeb.xcodeproj/project.pbxproj
@@ -41,8 +41,8 @@
 		842ED3001E12FBC1000CF738 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED2FE1E12FBC1000CF738 /* UserAgent.swift */; };
 		842ED3021E12FBC7000CF738 /* HTTPConditionalGetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED3011E12FBC7000CF738 /* HTTPConditionalGetInfo.swift */; };
 		842ED3031E12FBC7000CF738 /* HTTPConditionalGetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED3011E12FBC7000CF738 /* HTTPConditionalGetInfo.swift */; };
-		842ED3051E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED3041E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift */; };
-		842ED3061E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED3041E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift */; };
+		842ED3051E12FBCC000CF738 /* URLRequest+RSWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED3041E12FBCC000CF738 /* URLRequest+RSWeb.swift */; };
+		842ED3061E12FBCC000CF738 /* URLRequest+RSWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED3041E12FBCC000CF738 /* URLRequest+RSWeb.swift */; };
 		842ED30B1E12FBD8000CF738 /* URL+RSWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED30A1E12FBD8000CF738 /* URL+RSWeb.swift */; };
 		842ED30C1E12FBD8000CF738 /* URL+RSWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED30A1E12FBD8000CF738 /* URL+RSWeb.swift */; };
 		842ED30E1E12FBDD000CF738 /* URLResponse+RSWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842ED30D1E12FBDD000CF738 /* URLResponse+RSWeb.swift */; };
@@ -84,7 +84,7 @@
 		842ED2FB1E12FBBB000CF738 /* DownloadObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DownloadObject.swift; path = RSWeb/DownloadObject.swift; sourceTree = "<group>"; };
 		842ED2FE1E12FBC1000CF738 /* UserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		842ED3011E12FBC7000CF738 /* HTTPConditionalGetInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPConditionalGetInfo.swift; sourceTree = "<group>"; };
-		842ED3041E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableURLRequest+RSWeb.swift"; sourceTree = "<group>"; };
+		842ED3041E12FBCC000CF738 /* URLRequest+RSWeb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLRequest+RSWeb.swift"; sourceTree = "<group>"; };
 		842ED30A1E12FBD8000CF738 /* URL+RSWeb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "URL+RSWeb.swift"; path = "RSWeb/URL+RSWeb.swift"; sourceTree = "<group>"; };
 		842ED30D1E12FBDD000CF738 /* URLResponse+RSWeb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLResponse+RSWeb.swift"; sourceTree = "<group>"; };
 		842ED3101E12FBE1000CF738 /* MacWebBrowser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MacWebBrowser.swift; path = RSWeb/MacWebBrowser.swift; sourceTree = "<group>"; };
@@ -163,7 +163,7 @@
 				51E49032228866A400C791F0 /* HTTPLinkPagingInfo.swift */,
 				842ED3101E12FBE1000CF738 /* MacWebBrowser.swift */,
 				842ED3131E12FBE7000CF738 /* MimeType.swift */,
-				842ED3041E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift */,
+				842ED3041E12FBCC000CF738 /* URLRequest+RSWeb.swift */,
 				8409DB2F200AE81400CE879E /* String+RSWeb.swift */,
 				842ED30D1E12FBDD000CF738 /* URLResponse+RSWeb.swift */,
 				842ED30A1E12FBD8000CF738 /* URL+RSWeb.swift */,
@@ -445,7 +445,7 @@
 				842ED2F61E12FBAF000CF738 /* OneShotDownload.swift in Sources */,
 				842ED2F31E12FBAA000CF738 /* DownloadSession.swift in Sources */,
 				510C86182288EBB400FA2488 /* HTTPDateInfo.swift in Sources */,
-				842ED3051E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift in Sources */,
+				842ED3051E12FBCC000CF738 /* URLRequest+RSWeb.swift in Sources */,
 				51E49033228866A400C791F0 /* HTTPLinkPagingInfo.swift in Sources */,
 				51EC99CF227DBC1F002E55C9 /* Transport.swift in Sources */,
 				842ED2E71E12FB8A000CF738 /* HTTPRequestHeader.swift in Sources */,
@@ -486,7 +486,7 @@
 				51EC99D0227DBC1F002E55C9 /* Transport.swift in Sources */,
 				5113B87122ADBAFC0018040E /* String+RSWeb.swift in Sources */,
 				842ED2F11E12FB9B000CF738 /* HTTPResponseHeader.swift in Sources */,
-				842ED3061E12FBCC000CF738 /* NSMutableURLRequest+RSWeb.swift in Sources */,
+				842ED3061E12FBCC000CF738 /* URLRequest+RSWeb.swift in Sources */,
 				842ED2F41E12FBAA000CF738 /* DownloadSession.swift in Sources */,
 				512B10A02350E52A009C4920 /* Dictionary+RSWeb.swift in Sources */,
 				842ED2EE1E12FB97000CF738 /* HTTPResponseCode.swift in Sources */,

--- a/RSWeb/String+RSWeb.swift
+++ b/RSWeb/String+RSWeb.swift
@@ -8,25 +8,7 @@
 
 import Foundation
 
-extension CharacterSet {
-
-	/// Characters allowed in an URL query name or value.
-	///
-	/// Identical to `.urlQueryAllowed` without `&` or `=`.
-	static let urlQueryItemAllowed: CharacterSet = {
-		var allowedCharacters = CharacterSet.urlQueryAllowed
-		allowedCharacters.remove(charactersIn: "&=")
-		return allowedCharacters
-	}()
-
-}
-
 public extension String {
-
-	/// Returns `self` percent-encoded for use as a name or value in a URL query.
-	var encodedForURLQuery: String? {
-		return addingPercentEncoding(withAllowedCharacters: .urlQueryItemAllowed)
-	}
 
 	/// Escapes special HTML characters.
 	///

--- a/RSWeb/String+RSWeb.swift
+++ b/RSWeb/String+RSWeb.swift
@@ -10,6 +10,9 @@ import Foundation
 
 extension CharacterSet {
 
+	/// Characters allowed in an URL query name or value.
+	///
+	/// Identical to `.urlQueryAllowed` without `&` or `=`.
 	static let urlQueryItemAllowed: CharacterSet = {
 		var allowedCharacters = CharacterSet.urlQueryAllowed
 		allowedCharacters.remove(charactersIn: "&=")
@@ -20,11 +23,15 @@ extension CharacterSet {
 
 public extension String {
 
+	/// Returns `self` percent-encoded for use as a name or value in a URL query.
 	var encodedForURLQuery: String? {
 		return addingPercentEncoding(withAllowedCharacters: .urlQueryItemAllowed)
 	}
-	
-	var escapeHTML: String {
+
+	/// Escapes special HTML characters.
+	///
+	/// Escaped characters are `&`, `<`, `>`, `"`, and `'`.
+	var escapedHTML: String {
 		var escaped = String()
 
 		for char in self {
@@ -37,6 +44,8 @@ public extension String {
 					escaped.append("&gt;")
 				case "\"":
 					escaped.append("&quot;")
+				case "'":
+					escaped.append("&apos;")
 				default:
 					escaped.append(char)
 			}

--- a/RSWeb/String+RSWeb.swift
+++ b/RSWeb/String+RSWeb.swift
@@ -8,23 +8,41 @@
 
 import Foundation
 
+extension CharacterSet {
+
+	static let urlQueryItemAllowed: CharacterSet = {
+		var allowedCharacters = CharacterSet.urlQueryAllowed
+		allowedCharacters.remove(charactersIn: "&=")
+		return allowedCharacters
+	}()
+
+}
+
 public extension String {
 
-	func encodedForURLQuery() -> String? {
-
-		guard let encodedString = addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-			return nil
-		}
-		return encodedString.replacingOccurrences(of: "&", with: "%38")
+	var encodedForURLQuery: String? {
+		return addingPercentEncoding(withAllowedCharacters: .urlQueryItemAllowed)
 	}
 	
-	func escapeHTML() -> String {
-		var result = self.replacingOccurrences(of: "&", with: "&amp;")
-		result = result.replacingOccurrences(of: "\"", with: "&quot;")
-		result = result.replacingOccurrences(of: "'", with: "&#x27;")
-		result = result.replacingOccurrences(of: ">", with: "&gt;")
-		result = result.replacingOccurrences(of: "<", with: "&lt;")
-		return result
+	var escapeHTML: String {
+		var escaped = String()
+
+		for char in self {
+			switch char {
+				case "&":
+					escaped.append("&amp;")
+				case "<":
+					escaped.append("&lt;")
+				case ">":
+					escaped.append("&gt;")
+				case "\"":
+					escaped.append("&quot;")
+				default:
+					escaped.append(char)
+			}
+		}
+
+		return escaped
 	}
 	
 }

--- a/RSWebTests/DictionaryTests.swift
+++ b/RSWebTests/DictionaryTests.swift
@@ -13,7 +13,7 @@ class DictionaryTests: XCTestCase {
 	func testSimpleQueryString() {
 
 		let d = ["foo": "bar", "param1": "This is a value."]
-		let s = d.urlQueryString()
+		let s = d.urlQueryString
 
 		XCTAssertTrue(s == "foo=bar&param1=This%20is%20a%20value." || s == "param1=This%20is%20a%20value.&foo=bar")
 	}
@@ -21,15 +21,15 @@ class DictionaryTests: XCTestCase {
 	func testQueryStringWithAmpersand() {
 
 		let d = ["fo&o": "bar", "param1": "This is a&value."]
-		let s = d.urlQueryString()
+		let s = d.urlQueryString
 
-		XCTAssertTrue(s == "fo%38o=bar&param1=This%20is%20a%38value." || s == "param1=This%20is%20a%38value.&fo%38o=bar")
+		XCTAssertTrue(s == "fo%26o=bar&param1=This%20is%20a%26value." || s == "param1=This%20is%20a%26value.&fo%26o=bar")
 	}
 
 	func testQueryStringWithAccentedCharacters() {
 
 		let d = ["fée": "bør"]
-		let s = d.urlQueryString()
+		let s = d.urlQueryString
 
 		XCTAssertTrue(s == "f%C3%A9e=b%C3%B8r")
 	}
@@ -37,7 +37,7 @@ class DictionaryTests: XCTestCase {
 	func testQueryStringWithEmoji() {
 
 		let d = ["🌴e": "bar🎩🌴"]
-		let s = d.urlQueryString()
+		let s = d.urlQueryString
 
 		XCTAssertTrue(s == "%F0%9F%8C%B4e=bar%F0%9F%8E%A9%F0%9F%8C%B4")
 	}

--- a/RSWebTests/StringTests.swift
+++ b/RSWebTests/StringTests.swift
@@ -10,19 +10,10 @@ import XCTest
 
 class StringTests: XCTestCase {
 
-    func testURLQueryEncoding() {
+    func testHTMLEscaping() {
 
-		var s = "foo".encodedForURLQuery
-		XCTAssertEqual(s, "foo")
-
-		s = "foo bar".encodedForURLQuery
-		XCTAssertEqual(s, "foo%20bar")
-
-		s = "foo bar &well".encodedForURLQuery
-		XCTAssertEqual(s, "foo%20bar%20%26well")
-
-		s = "foo bar =well".encodedForURLQuery
-		XCTAssertEqual(s, "foo%20bar%20%3Dwell")
+		let s = #"<foo>"bar"&'baz'"#.escapedHTML
+		XCTAssertEqual(s, "&lt;foo&gt;&quot;bar&quot;&amp;&apos;baz&apos;")
 
     }
 }

--- a/RSWebTests/StringTests.swift
+++ b/RSWebTests/StringTests.swift
@@ -12,13 +12,17 @@ class StringTests: XCTestCase {
 
     func testURLQueryEncoding() {
 
-		var s = "foo".encodedForURLQuery()
+		var s = "foo".encodedForURLQuery
 		XCTAssertEqual(s, "foo")
 
-		s = "foo bar".encodedForURLQuery()
+		s = "foo bar".encodedForURLQuery
 		XCTAssertEqual(s, "foo%20bar")
 
-		s = "foo bar &well".encodedForURLQuery()
-		XCTAssertEqual(s, "foo%20bar%20%38well")
+		s = "foo bar &well".encodedForURLQuery
+		XCTAssertEqual(s, "foo%20bar%20%26well")
+
+		s = "foo bar =well".encodedForURLQuery
+		XCTAssertEqual(s, "foo%20bar%20%3Dwell")
+
     }
 }

--- a/URLRequest+RSWeb.swift
+++ b/URLRequest+RSWeb.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-public extension NSMutableURLRequest {
+public extension URLRequest {
 
-	func addBasicAuthorization(username: String, password: String) -> Bool {
+	@discardableResult mutating func addBasicAuthorization(username: String, password: String) -> Bool {
 		
 		// Do this *only* with https. And not even then if you can help it.
 		
 		let s = "\(username):\(password)"
-		guard let d = s.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
+		guard let d = s.data(using: .utf8, allowLossyConversion: false) else {
 			return false
 		}
 		

--- a/URLResponse+RSWeb.swift
+++ b/URLResponse+RSWeb.swift
@@ -16,7 +16,7 @@ public extension URLResponse {
 	
 	var forcedStatusCode: Int {
 		
-		// Return actual statusCode or -1 if there isn’t one.
+		// Return actual statusCode or 0 if there isn’t one.
 		
 		if let response = self as? HTTPURLResponse {
 			return response.statusCode

--- a/xcconfig/RSWeb_ios_target.xcconfig
+++ b/xcconfig/RSWeb_ios_target.xcconfig
@@ -7,6 +7,7 @@ DEVELOPMENT_TEAM = 9C84TZ7Q6Z
 // DeveloperSettings.xcconfig is #included here
 
 #include? "../../../SharedXcodeSettings/DeveloperSettings.xcconfig"
+#include? "../SharedXcodeSettings/DeveloperSettings.xcconfig"
 
 SDKROOT = iphoneos
 TARGETED_DEVICE_FAMILY = 1,2

--- a/xcconfig/RSWeb_mac_target.xcconfig
+++ b/xcconfig/RSWeb_mac_target.xcconfig
@@ -9,6 +9,7 @@ PROVISIONING_PROFILE_SPECIFIER =
 // DeveloperSettings.xcconfig is #included here
 
 #include? "../../../SharedXcodeSettings/DeveloperSettings.xcconfig"
+#include? "../SharedXcodeSettings/DeveloperSettings.xcconfig"
 
 INFOPLIST_FILE = RSWeb/Info.plist
 PRODUCT_BUNDLE_IDENTIFIER = com.ranchero.RSWeb


### PR DESCRIPTION
- Refactors the `Dictionary` extension to be conditional on keys and values being strings, and uses `URLComponents`/`URLQueryItem` for the escaping. This obviates the need for the URL encoding method on `String`.
- Changes the `NSMutableURLRequest` extension to be on `URLRequest` instead, with a `mutating` method (and change the parameter on an `HTTPConditionalGetInfo` method to `inout`).
- Changes some getter-like functions to computed properties.
- (Also fixes a misencoding of `"&"`.)