### PR TITLE
Fix a Swift 5.2 compilation error

### DIFF
--- a/RSWeb/WebServices/TransportJSON.swift
+++ b/RSWeb/WebServices/TransportJSON.swift
@@ -71,7 +71,7 @@ extension Transport {
 		send(request: postRequest, method: method, payload: data) { result in
 			DispatchQueue.main.async {
 				switch result {
-				case .success(_, _):
+				case .success((_, _)):
 					completion(.success(()))
 				case .failure(let error):
 					completion(.failure(error))


### PR DESCRIPTION
Swift 5.2 requires either additional parentheses (added in this edit) or a single underscore (to ignore the entire tuple).