### PR TITLE
Use a static constant instead of an explicit value

### DIFF
--- a/RSWeb/OneShotDownload.swift
+++ b/RSWeb/OneShotDownload.swift
@@ -138,7 +138,7 @@ private final class DownloadWithCacheManager {
 
 	func download(_ url: URL, _ completion: @escaping OneShotDownloadCallback) {
 
-		if lastCleanupDate.timeIntervalSinceNow < -(5 * 60) {
+		if lastCleanupDate.timeIntervalSinceNow < -DownloadWithCacheManager.cleanupInterval {
 			lastCleanupDate = Date()
 			cache.cleanup(DownloadWithCacheManager.timeToLive)
 		}


### PR DESCRIPTION
Replaces the hardcoded integer with an already-defined constant having the same value