### PR TITLE
MacWebBrowser updates

### DIFF
--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -29,7 +29,7 @@ public class MacWebBrowser {
 		return NSWorkspace.shared.open(preparedURL)
 	}
 
-	/// The bundle identifier of the default web browser.
+	/// The filesystem URL of the default web browser.
 	class var defaultBrowserURL: URL? {
 		return LSCopyDefaultApplicationURLForURL(URL(string: "https:///")! as CFURL, .viewer, nil)?.takeRetainedValue() as URL?
 	}

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -34,37 +34,42 @@ public class MacWebBrowser {
 		return LSCopyDefaultApplicationURLForURL(URL(string: "https:///")! as CFURL, .viewer, nil)?.takeRetainedValue() as URL?
 	}
 
-	/// The icon of the default web browser.
-	public class var defaultBrowserIcon: NSImage? {
-		if let browserURL = defaultBrowserURL {
-			if let values = try? browserURL.resourceValues(forKeys: [.effectiveIconKey]) {
-				return values.effectiveIcon as? NSImage
-			}
+	public class var `default`: MacWebBrowser {
+		return MacWebBrowser(url: defaultBrowserURL!)
+	}
+
+	let url: URL
+
+	public lazy var icon: NSImage? = {
+		if let values = try? url.resourceValues(forKeys: [.effectiveIconKey]) {
+			return values.effectiveIcon as? NSImage
 		}
 
 		return nil
-	}
+	}()
 
-	public class var defaultBrowserName: String? {
-		if let browserURL = defaultBrowserURL {
-			if let values = try? browserURL.resourceValues(forKeys: [.localizedNameKey]), var name = values.localizedName {
-				if let extensionRange = name.range(of: ".app", options: [.anchored, .backwards]) {
-					name = name.replacingCharacters(in: extensionRange, with: "")
-				}
-
-				return name
+	public lazy var name: String? = {
+		if let values = try? url.resourceValues(forKeys: [.localizedNameKey]), var name = values.localizedName {
+			if let extensionRange = name.range(of: ".app", options: [.anchored, .backwards]) {
+				name = name.replacingCharacters(in: extensionRange, with: "")
 			}
+
+			return name
 		}
 
 		return nil
-	}
+	}()
 
-	public class var defaultBrowserBundleIdentifier: String? {
-		if let browserURL = defaultBrowserURL, let bundle = Bundle(url: browserURL) {
+	public lazy var bundleIdentifier: String? = {
+		if let bundle = Bundle(url: url) {
 			return bundle.bundleIdentifier
 		}
 
 		return nil
+	}()
+
+	init(url: URL) {
+		self.url = url
 	}
 }
 

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -28,6 +28,24 @@ public class MacWebBrowser {
 		
 		return NSWorkspace.shared.open(preparedURL)
 	}
+
+	/// The bundle identifier of the default web browser.
+	class var defaultBundleIdentifier: String? {
+		return LSCopyDefaultHandlerForURLScheme("https" as CFString)?.takeRetainedValue() as String?
+	}
+
+	/// The icon of the default web browser.
+	class var defaultBrowserIcon: NSImage? {
+		if let bundleid = defaultBundleIdentifier {
+			if let browserURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleid) {
+				if let values = try? browserURL.resourceValues(forKeys: [.effectiveIconKey]) {
+					return values.effectiveIcon as? NSImage
+				}
+			}
+		}
+
+		return nil
+	}
 }
 
 private extension URL {

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -58,6 +58,14 @@ public class MacWebBrowser {
 
 		return nil
 	}
+
+	public class var defaultBrowserBundleIdentifier: String? {
+		if let browserURL = defaultBrowserURL, let bundle = Bundle(url: browserURL) {
+			return bundle.bundleIdentifier
+		}
+
+		return nil
+	}
 }
 
 private extension URL {

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -66,8 +66,7 @@ public class MacWebBrowser {
 	/// The filesystem URL of the web browser.
 	public let url: URL
 
-	/// The application icon of the web browser.
-	public private(set) lazy var icon: NSImage? = {
+	private lazy var _icon: NSImage? = {
 		if let values = try? url.resourceValues(forKeys: [.effectiveIconKey]) {
 			return values.effectiveIcon as? NSImage
 		}
@@ -75,8 +74,12 @@ public class MacWebBrowser {
 		return nil
 	}()
 
-	/// The localized name of the web browser, with any `.app` extension removed.
-	public private(set) lazy var name: String? = {
+	/// The application icon of the web browser.
+	public var icon: NSImage? {
+		return _icon
+	}
+
+	private lazy var _name: String? = {
 		if let values = try? url.resourceValues(forKeys: [.localizedNameKey]), var name = values.localizedName {
 			if let extensionRange = name.range(of: ".app", options: [.anchored, .backwards]) {
 				name = name.replacingCharacters(in: extensionRange, with: "")
@@ -88,10 +91,19 @@ public class MacWebBrowser {
 		return nil
 	}()
 
-	/// The bundle identifier of the web browser.
-	public private(set) lazy var bundleIdentifier: String? = {
+	/// The localized name of the web browser, with any `.app` extension removed.
+	public var name: String? {
+		return _name
+	}
+
+	private lazy var _bundleIdentifier: String? = {
 		return Bundle(url: url)?.bundleIdentifier
 	}()
+
+	/// The bundle identifier of the web browser.
+	public var bundleIdentifier: String? {
+		return _bundleIdentifier
+	}
 
 	/// Initializes a `MacWebBrowser` with a URL on disk.
 	/// - Parameter url: The filesystem URL of the browser.

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -67,7 +67,7 @@ public class MacWebBrowser {
 	public let url: URL
 
 	/// The application icon of the web browser.
-	public lazy var icon: NSImage? = {
+	public private(set) lazy var icon: NSImage? = {
 		if let values = try? url.resourceValues(forKeys: [.effectiveIconKey]) {
 			return values.effectiveIcon as? NSImage
 		}
@@ -76,7 +76,7 @@ public class MacWebBrowser {
 	}()
 
 	/// The localized name of the web browser, with any `.app` extension removed.
-	public lazy var name: String? = {
+	public private(set) lazy var name: String? = {
 		if let values = try? url.resourceValues(forKeys: [.localizedNameKey]), var name = values.localizedName {
 			if let extensionRange = name.range(of: ".app", options: [.anchored, .backwards]) {
 				name = name.replacingCharacters(in: extensionRange, with: "")
@@ -89,7 +89,7 @@ public class MacWebBrowser {
 	}()
 
 	/// The bundle identifier of the web browser.
-	public lazy var bundleIdentifier: String? = {
+	public private(set) lazy var bundleIdentifier: String? = {
 		return Bundle(url: url)?.bundleIdentifier
 	}()
 

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -44,6 +44,20 @@ public class MacWebBrowser {
 
 		return nil
 	}
+
+	public class var defaultBrowserName: String? {
+		if let browserURL = defaultBrowserURL {
+			if let values = try? browserURL.resourceValues(forKeys: [.localizedNameKey]), var name = values.localizedName {
+				if let extensionRange = name.range(of: ".app", options: [.anchored, .backwards]) {
+					name = name.replacingCharacters(in: extensionRange, with: "")
+				}
+
+				return name
+			}
+		}
+
+		return nil
+	}
 }
 
 private extension URL {

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -30,17 +30,15 @@ public class MacWebBrowser {
 	}
 
 	/// The bundle identifier of the default web browser.
-	class var defaultBundleIdentifier: String? {
-		return LSCopyDefaultHandlerForURLScheme("https" as CFString)?.takeRetainedValue() as String?
+	class var defaultBrowserURL: URL? {
+		return LSCopyDefaultApplicationURLForURL(URL(string: "https:///")! as CFURL, .viewer, nil)?.takeRetainedValue() as URL?
 	}
 
 	/// The icon of the default web browser.
 	public class var defaultBrowserIcon: NSImage? {
-		if let bundleid = defaultBundleIdentifier {
-			if let browserURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleid) {
-				if let values = try? browserURL.resourceValues(forKeys: [.effectiveIconKey]) {
-					return values.effectiveIcon as? NSImage
-				}
+		if let browserURL = defaultBrowserURL {
+			if let values = try? browserURL.resourceValues(forKeys: [.effectiveIconKey]) {
+				return values.effectiveIcon as? NSImage
 			}
 		}
 

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -87,13 +87,13 @@ public class MacWebBrowser {
 
 	/// Initializes a `MacWebBrowser` with a URL on disk.
 	/// - Parameter url: The filesystem URL of the browser.
-	init(url: URL) {
+	public init(url: URL) {
 		self.url = url
 	}
 
 	/// Initializes a `MacWebBrowser` from a bundle identifier.
 	/// - Parameter bundleIdentifier: The bundle identifier of the browser.
-	convenience init?(bundleIdentifier: String) {
+	public convenience init?(bundleIdentifier: String) {
 		guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
 			return nil
 		}

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -32,9 +32,15 @@ public class MacWebBrowser {
 
 	/// Returns an array of MacWebBrowser, sorted by name.
 	public class func sortedBrowsers() -> [MacWebBrowser] {
-		guard let browserIDs = LSCopyAllHandlersForURLScheme("https" as CFString)?.takeRetainedValue() as? [String] else {
+		guard let httpsIDs = LSCopyAllHandlersForURLScheme("https" as CFString)?.takeRetainedValue() as? [String] else {
 			return []
 		}
+
+		guard let htmlIDs = LSCopyAllRoleHandlersForContentType(kUTTypeHTML, .viewer)?.takeRetainedValue() as? [String] else {
+			return []
+		}
+
+		let browserIDs = Set(httpsIDs).intersection(Set(htmlIDs))
 
 		return browserIDs.compactMap { MacWebBrowser(bundleIdentifier: $0) }.sorted {
 			if let leftName = $0.name, let rightName = $1.name {

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -30,7 +30,9 @@ public class MacWebBrowser {
 		return NSWorkspace.shared.open(preparedURL)
 	}
 
-	/// Returns an array of MacWebBrowser, sorted by name.
+	/// Returns an array of the browsers installed on the system, sorted by name.
+	///
+	/// "Browsers" are applications that can both handle `https` URLs, and display HTML documents.
 	public class func sortedBrowsers() -> [MacWebBrowser] {
 		guard let httpsIDs = LSCopyAllHandlersForURLScheme("https" as CFString)?.takeRetainedValue() as? [String] else {
 			return []
@@ -62,7 +64,7 @@ public class MacWebBrowser {
 	}
 
 	/// The filesystem URL of the web browser.
-	let url: URL
+	public let url: URL
 
 	/// The application icon of the web browser.
 	public lazy var icon: NSImage? = {

--- a/RSWeb/MacWebBrowser.swift
+++ b/RSWeb/MacWebBrowser.swift
@@ -35,7 +35,7 @@ public class MacWebBrowser {
 	}
 
 	/// The icon of the default web browser.
-	class var defaultBrowserIcon: NSImage? {
+	public class var defaultBrowserIcon: NSImage? {
 		if let bundleid = defaultBundleIdentifier {
 			if let browserURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleid) {
 				if let values = try? browserURL.resourceValues(forKeys: [.effectiveIconKey]) {

--- a/RSWebTests/RSWebTests.swift
+++ b/RSWebTests/RSWebTests.swift
@@ -32,5 +32,11 @@ class RSWebTests: XCTestCase {
             // Put the code you want to measure the time of here.
         }
     }
+
+	func testAllBrowsers() {
+		let browsers = MacWebBrowser.sortedBrowsers()
+
+		XCTAssertNotNil(browsers);
+	}
     
 }


### PR DESCRIPTION
Makes `MacWebBrowser` instantiable and adds a static method for getting all installed browsers (for an upcoming NNW pref for setting the default browser).