### PR TITLE
Fix loading of the uts46 file when built as a Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "RSWeb",
-            dependencies: [],
 			resources: [.copy("UTS46/uts46")],
 			swiftSettings: [.define("SWIFT_PACKAGE")]),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
         .target(
             name: "RSWeb",
             dependencies: [],
-            resources: [.copy("UTS46/uts46")]),
+			resources: [.copy("UTS46/uts46")],
+			swiftSettings: [SwiftSetting.define("SWIFT_PACKAGE")]),
         .testTarget(
             name: "RSWebTests",
             dependencies: ["RSWeb"]),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
             name: "RSWeb",
             dependencies: [],
 			resources: [.copy("UTS46/uts46")],
-			swiftSettings: [SwiftSetting.define("SWIFT_PACKAGE")]),
+			swiftSettings: [.define("SWIFT_PACKAGE")]),
         .testTarget(
             name: "RSWebTests",
             dependencies: ["RSWeb"]),

--- a/Sources/RSWeb/UTS46/UTS46+Loading.swift
+++ b/Sources/RSWeb/UTS46/UTS46+Loading.swift
@@ -59,9 +59,17 @@ extension UTS46 {
 		isLoaded = true
 	}
 
+	static var bundle: Bundle {
+		#if SWIFT_PACKAGE
+		return Bundle.module
+		#else
+		return Bundle(for: Self.self)
+		#endif
+	}
+
 	static func loadIfNecessary() throws {
 		guard !isLoaded else { return }
-		guard let url = Bundle.module.url(forResource: "uts46", withExtension: nil) else { throw CocoaError(.fileNoSuchFile) }
+		guard let url = Self.bundle.url(forResource: "uts46", withExtension: nil) else { throw CocoaError(.fileNoSuchFile) }
 
 		try load(from: url)
 	}

--- a/Sources/RSWeb/UTS46/UTS46+Loading.swift
+++ b/Sources/RSWeb/UTS46/UTS46+Loading.swift
@@ -61,7 +61,7 @@ extension UTS46 {
 
 	static func loadIfNecessary() throws {
 		guard !isLoaded else { return }
-		guard let url = Bundle(for: Self.self).url(forResource: "uts46", withExtension: nil) else { throw CocoaError(.fileNoSuchFile) }
+		guard let url = Bundle.module.url(forResource: "uts46", withExtension: nil) else { throw CocoaError(.fileNoSuchFile) }
 
 		try load(from: url)
 	}


### PR DESCRIPTION
Base fix for Ranchero-Software/NetNewsWire/issues/2311.

RSWeb references in NNW will need to be updated, of course.