### PR TITLE
Set the fragment to the empty string if scanning returns nil (5.1 branch)

### DIFF
--- a/UTS46/String+Punycode.swift
+++ b/UTS46/String+Punycode.swift
@@ -406,7 +406,7 @@ private extension String {
 
 		if !s.isAtEnd {
 			_ = s.shimScanString("#")
-			fragment = s.shimScanUpToCharacters(from: .newlines)!
+			fragment = s.shimScanUpToCharacters(from: .newlines) ?? ""
 		}
 
 		let usernamePasswordHostPort = host.components(separatedBy: "@")


### PR DESCRIPTION
Fix for https://github.com/Ranchero-Software/NetNewsWire/issues/2445.