### PR TITLE
Replace remaining force-unwraps (5.1 branch)

### DIFF
--- a/UTS46/String+Punycode.swift
+++ b/UTS46/String+Punycode.swift
@@ -377,18 +377,11 @@ private extension String {
 		var fragment: String?
 
 		if let hostOrScheme = s.shimScanUpToCharacters(from: colonSlash) {
-			if !s.isAtEnd {
-				delim = s.shimScanCharacters(from: colonSlash)!
+			delim = s.shimScanCharacters(from: colonSlash) ?? ""
 
-				if delim.hasPrefix(":") {
-					scheme = hostOrScheme
-
-					if !s.isAtEnd {
-						host = s.shimScanUpToCharacters(from: slashQuestion)!
-					}
-				} else {
-					host = hostOrScheme
-				}
+			if delim.hasPrefix(":") {
+				scheme = hostOrScheme
+				host = s.shimScanUpToCharacters(from: slashQuestion) ?? ""
 			} else {
 				host = hostOrScheme
 			}
@@ -400,12 +393,9 @@ private extension String {
 			}
 		}
 
-		if !s.isAtEnd {
-			path = s.shimScanUpToString("#")!
-		}
+		path = s.shimScanUpToString("#") ?? ""
 
-		if !s.isAtEnd {
-			_ = s.shimScanString("#")
+		if s.shimScanString("#") != nil {
 			fragment = s.shimScanUpToCharacters(from: .newlines) ?? ""
 		}
 


### PR DESCRIPTION
Fixes a crash parsing, e.g., "https://?".

Fixes Ranchero-Software/NetNewsWire/issues/2463.