### PR TITLE
Return an unexpected response if the redirect its the same that the original url

### DIFF
--- a/Sources/RSWeb/DownloadSession.swift
+++ b/Sources/RSWeb/DownloadSession.swift
@@ -104,10 +104,21 @@ extension DownloadSession: URLSessionTaskDelegate {
 		
 		if response.statusCode == 301 || response.statusCode == 308 {
 			if let oldURLString = task.originalRequest?.url?.absoluteString, let newURLString = request.url?.absoluteString {
-				cacheRedirect(oldURLString, newURLString)
+                guard oldURLString != newURLString  else {
+                    if let representedObject = infoForTask(task)?.representedObject {
+                        delegate.downloadSession(self, didReceiveUnexpectedResponse: response, representedObject: representedObject)
+                    }
+
+                    completionHandler(nil)
+                    removeTask(task)
+
+                    return
+                }
+
+                cacheRedirect(oldURLString, newURLString)
 			}
 		}
-		
+
 		completionHandler(request)
 	}
 }
@@ -219,7 +230,7 @@ private extension DownloadSession {
 		taskIdentifierToInfoDictionary[task.taskIdentifier] = nil
 
 		addDataTaskFromQueueIfNecessary()
-		
+
 		if tasksInProgress.count + tasksPending.count < 1 {
 			representedObjects.removeAllObjects()
 			delegate.downloadSessionDidCompleteDownloadObjects(self)


### PR DESCRIPTION
I have an issue with an url (https://hipertextual.com/feed). Every time that I tried to get the articles, this endpoint redirects, several times to the same url.

This little update help to avoid the problem where the redirect url is the same that the original and returns an error.